### PR TITLE
fix: RDP mode caused the revert-setting-warning-log flood

### DIFF
--- a/src/nvenc/common_impl/nvenc_base.cpp
+++ b/src/nvenc/common_impl/nvenc_base.cpp
@@ -542,7 +542,7 @@ namespace nvenc {
 
     NV_ENC_LOCK_BITSTREAM lock_bitstream = { NV_ENC_LOCK_BITSTREAM_VER };
     lock_bitstream.outputBitstream = output_bitstream;
-    lock_bitstream.doNotWait = 0;
+    lock_bitstream.doNotWait = async_event_handle ? 1 : 0;
 
     if (async_event_handle && !wait_for_async_event(100)) {
       BOOST_LOG(error) << "NvEnc: frame " << frame_index << " encode wait timeout";

--- a/src/nvenc/win/impl/nvenc_d3d11_base.cpp
+++ b/src/nvenc/win/impl/nvenc_d3d11_base.cpp
@@ -9,9 +9,19 @@ namespace NVENC_NAMESPACE {
 #else
 namespace nvenc {
 #endif
+  nvenc_d3d11_base::nvenc_d3d11_base(NV_ENC_DEVICE_TYPE device_type, shared_dll dll):
+      nvenc_base(device_type),
+      dll(dll) {
+    async_event_handle = CreateEvent(NULL, FALSE, FALSE, NULL);
+  }
 
-  bool
-  nvenc_d3d11_base::init_library() {
+  nvenc_d3d11_base::~nvenc_d3d11_base() {
+    if (async_event_handle) {
+      CloseHandle(async_event_handle);
+    }
+  }
+
+  bool nvenc_d3d11_base::init_library() {
     if (nvenc) return true;
     if (!dll) return false;
 
@@ -31,5 +41,9 @@ namespace nvenc {
     }
 
     return false;
+  }
+  
+  bool nvenc_d3d11_base::wait_for_async_event(uint32_t timeout_ms) {
+    return WaitForSingleObject(async_event_handle, timeout_ms) == WAIT_OBJECT_0;
   }
 }

--- a/src/nvenc/win/impl/nvenc_d3d11_base.h
+++ b/src/nvenc/win/impl/nvenc_d3d11_base.h
@@ -28,13 +28,11 @@ namespace nvenc {
    */
   class nvenc_d3d11_base: public nvenc_base, virtual public nvenc_d3d11 {
   public:
-    nvenc_d3d11_base(NV_ENC_DEVICE_TYPE device_type, shared_dll dll):
-        nvenc_base(device_type),
-        dll(dll) {}
-
+    explicit nvenc_d3d11_base(NV_ENC_DEVICE_TYPE device_type, shared_dll dll);
+    ~nvenc_d3d11_base();
   protected:
-    bool
-    init_library() override;
+    bool init_library() override;
+    bool wait_for_async_event(uint32_t timeout_ms) override;
 
   private:
     shared_dll dll;

--- a/src/platform/windows/display_device/windows_utils.h
+++ b/src/platform/windows/display_device/windows_utils.h
@@ -493,4 +493,16 @@ namespace display_device::w_utils {
 
   bool
   togglePnpDeviceByFriendlyName(const std::string &friendlyName, const bool &stat);
+
+  /**
+   * @brief Check whether any RDP session is active.
+   * @returns True if it's detected that any RDP session is active, false otherwise.
+   *
+   * EXAMPLES:
+   * ```cpp
+   * const bool is_rdp { is_any_rdp_session_active() };
+   * ```
+   */
+  bool
+  is_any_rdp_session_active();
 }  // namespace display_device::w_utils


### PR DESCRIPTION
修复rdp远程模式下，回退配置警告日志刷屏：“Reverting display settings will still fail - retrying later..”
增加了20次的最大上限次数，避免其他情况导致程序一直在后台刷屏。

rdp检测采用检测所有会话，只要有一个用户会话是RDP模式，在结束串流以后，就不会触发回退配置。

跟踪：在串流中进行rdp远程，再退出串流，可能产生逻辑冲突。